### PR TITLE
Update homing.cfg

### DIFF
--- a/macros/helpers/homing.cfg
+++ b/macros/helpers/homing.cfg
@@ -11,7 +11,7 @@ gcode:
     SET_TMC_CURRENT STEPPER=stepper_x CURRENT={HOME_CURRENT}
     SET_TMC_CURRENT STEPPER=stepper_y CURRENT={HOME_CURRENT}
     
-    SET_KINEMATIC_POSITION X=15
+    SET_KINEMATIC_POSITION X=15 SET_HOMED=X
     G91
     G1 X-15 F1200
     
@@ -35,7 +35,7 @@ gcode:
     SET_TMC_CURRENT STEPPER=stepper_x CURRENT={HOME_CURRENT}
     SET_TMC_CURRENT STEPPER=stepper_y CURRENT={HOME_CURRENT}
     
-    SET_KINEMATIC_POSITION Y=15
+    SET_KINEMATIC_POSITION Y=15 SET_HOMED=Y
     G91
     G1 Y-15 F1200
     
@@ -58,7 +58,7 @@ axes: xyz
 gcode:
   {% set home_all = 'X' not in params and 'Y' not in params and 'Z' not in params %}
 
-  SET_KINEMATIC_POSITION Z=1
+  SET_KINEMATIC_POSITION Z=1 SET_HOMED=Z
   G1 Z4 F1200
 
   {% if home_all or 'X' in params %}


### PR DESCRIPTION
Added the `SET_HOMED=` option to each SET_KINEMATIC_POSITION command in the homing override so it only "fake homes" the axis it is changing rather than all the axes. This is to stop a problem where a user can run `G28 Z` when X and Y are unhomed but the set_kinematic_position would fake-home X and Y and so the printer would try to move to X175 Y175 even though the toolhead position was unknown. This problem may have only been introduced because of set_kinematic_position changes in new (v0.13) klipper, or homing override changes, or it always existed. Tested adding SET_HOME on a printer that has an older klipper and the option is just ignored.